### PR TITLE
Initial Schema Formatting

### DIFF
--- a/docs_jekyll_uswds/_layouts/default.html
+++ b/docs_jekyll_uswds/_layouts/default.html
@@ -1,57 +1,33 @@
----
----
+--- ---
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: 'en-US' }}">
 
 <head>
-  {% include meta.html %}
-  {% include styles.html %}
-  {% if site.google_analytics_ua or site.dap_agency %}
-  {% include analytics.html %}
-  {% endif %}
-  <!-- <link rel="stylesheet" href="https://pages.nist.gov/nist-header-footer/css/nist-combined.css"> -->
-  <!-- <script src="https://pages.nist.gov/nist-header-footer/js/jquery-1.9.0.min.js" type="text/javascript" defer="defer"></script>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% include meta.html %} {% include styles.html %} {% if site.google_analytics_ua or site.dap_agency %} {% include analytics.html %} {% endif %}
+    <!-- <link rel="stylesheet" href="https://pages.nist.gov/nist-header-footer/css/nist-combined.css"> -->
+    <!-- <script src="https://pages.nist.gov/nist-header-footer/js/jquery-1.9.0.min.js" type="text/javascript" defer="defer"></script>
     <script src="https://pages.nist.gov/nist-header-footer/js/nist-header-footer.js" type="text/javascript" defer="defer"></script> -->
 </head>
 
 <body class="{{ layout.class }} {{ page.class }} {% if site.site_width %}site-{{ site.site_width }}{% endif %}">
 
-  {% include skipnav.html %}
-  {% include header.html %}
+    {% include skipnav.html %} {% include header.html %} {% assign hero = page.hero %} {% include components/hero.html %} {% if page.tagline and page.intro %}
+    <section class="usa-grid usa-section">
+        <div class="usa-width-one-third">
+            <h2>{{ page.tagline }}</h2>
+        </div>
+        <div class="usa-width-two-thirds">
+            {{ page.intro | markdownify }}
+        </div>
+    </section>
+    {% endif %} {% capture _graphics %} {% include graphic-list.html graphics=page.graphics %} {% endcapture %} {% if page.graphics_position != 'after' %} {{ _graphics }} {% endif %}
 
-  {% assign hero = page.hero %}
-  {% include components/hero.html %}
+    <main id="main-content" {% for _attr in layout.main %} {{ _attr[0] }}="{{ _attr[1] }}" {% endfor %}>
+        {{ content }}
+    </main>
 
-  {% if page.tagline and page.intro %}
-  <section class="usa-grid usa-section">
-    <div class="usa-width-one-third">
-      <h2>{{ page.tagline }}</h2>
-    </div>
-    <div class="usa-width-two-thirds">
-      {{ page.intro | markdownify }}
-    </div>
-  </section>
-  {% endif %}
-
-  {% capture _graphics %}
-  {% include graphic-list.html graphics=page.graphics %}
-  {% endcapture %}
-
-  {% if page.graphics_position != 'after' %}
-  {{ _graphics }}
-  {% endif %}
-
-  <main id="main-content" {% for _attr in layout.main %} {{ _attr[0] }}="{{ _attr[1] }}" {% endfor %}>
-    {{ content }}
-  </main>
-
-  {% if page.graphics_position == 'after' %}
-  {{ _graphics }}
-  {% endif %}
-
-  {% include footer.html %}
-
-  {% include scripts.html %}
+    {% if page.graphics_position == 'after' %} {{ _graphics }} {% endif %} {% include footer.html %} {% include scripts.html %}
 
 </body>
 

--- a/docs_jekyll_uswds/_sass/components/_nist-combined.scss
+++ b/docs_jekyll_uswds/_sass/components/_nist-combined.scss
@@ -4,155 +4,176 @@
  *
  */
 
+
 /* Header Styles */
+
 .nist-header {
-  background: #000;
-  font-family: Helvetica, Arial, sans-serif;
-  padding: 10px 16px 0;
-  font-size: 16px;
+    background: #000;
+    font-family: Helvetica, Arial, sans-serif;
+    padding: 10px 16px 0;
+    font-size: 16px;
 }
 
 .nist-header__logo-link {
-  display: inline-block;
-  height: 35px;
+    display: inline-block;
+    height: 35px;
 }
 
 .nist-header__logo-icon {
-  fill: #fff;
-  display: inline-block;
-  height: 16px;
-  position: relative;
-  top: -2px;
-  margin-right: 2px;
+    fill: #fff;
+    display: inline-block;
+    height: 16px;
+    position: relative;
+    top: -2px;
+    margin-right: 2px;
 }
 
 .nist-header__logo-image {
-  fill: #fff;
-  display: inline-block;
-  height: 24px;
-  width: 90px;
+    fill: #fff;
+    display: inline-block;
+    height: 24px;
+    width: 90px;
 }
+
 
 /* Limit main content area width */
+
 .nist-main {
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 1200px;
-  padding: 0 16px;
-  box-sizing: border-box;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1200px;
+    padding: 0 16px;
+    box-sizing: border-box;
 }
 
+
 /* Make sure body has no margin or padding when using only this header component */
+
 body {
-  padding: 0;
-  margin: 0;
+    padding: 0;
+    margin: 0;
 }
+
 
 /* Footer styles */
 
 .nist-footer {
-  background: #333333;
-  position: relative;
-  z-index: 200;
-  font-family: Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  box-sizing: border-box;
+    background: #333333;
+    position: relative;
+    z-index: 200;
+    font-family: Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    box-sizing: border-box;
 }
 
 .nist-footer__inner {
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 1200px;
-  padding: 0 16px;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1200px;
+    padding: 0 16px;
 }
 
 .nist-footer__inner:after {
-  content: "";
-  display: table;
-  clear: both;
+    content: "";
+    display: table;
+    clear: both;
 }
 
 .nist-footer {
-  background: #333333;
-  color: white;
-  padding: 40px 0px;
-  position: relative;
+    background: #333333;
+    color: white;
+    padding: 40px 0px;
+    position: relative;
 }
 
 .nist-footer a {
-  color: white;
-  text-decoration: none;
+    color: white;
+    text-decoration: none;
 }
 
 .nist-footer .nist-footer__logo img {
-  width: 200px;
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 30px;
+    width: 200px;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 30px;
 }
 
 .nist-footer__menu {
-  clear: both;
-  margin-bottom: 10px;
+    clear: both;
+    margin-bottom: 10px;
 }
 
 .nist-footer__menu.first {
-  padding-top: 20px;
+    padding-top: 20px;
 }
 
 .nist-footer__menu ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  text-align: center;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    text-align: center;
 }
 
 .nist-footer__menu-item {
-  display: inline-block;
-  font-size: 14px;
-  padding: 0;
-  margin-left: 0;
+    display: inline-block;
+    font-size: 14px;
+    padding: 0;
+    margin-left: 0;
 }
 
 .nist-footer__menu-item:after {
-  content: '|';
-  margin-right: 1.6px;
-  display: inherit;
-  position: static;
-  font: inherit;
-  line-height: inherit;
-  color: inherit;
+    content: '|';
+    margin-right: 1.6px;
+    display: inherit;
+    position: static;
+    font: inherit;
+    line-height: inherit;
+    color: inherit;
 }
 
 .nist-footer__menu-item:last-child:after {
-  content: none;
+    content: none;
 }
 
 .nist-footer__menu-item a {
-  font-weight: normal;
-  margin-right: 6px;
-  white-space: nowrap;
-  padding: 0.5em 0;
-  display: inline-block;
+    font-weight: normal;
+    margin-right: 6px;
+    white-space: nowrap;
+    padding: 0.5em 0;
+    display: inline-block;
 }
+
 
 /**
  * Stick footer to bottom of page
  * Source: https://css-tricks.com/couple-takes-sticky-footer/
  */
 
-html.nist-footer-bottom, 
+html.nist-footer-bottom,
 html.nist-footer-bottom body {
-  height: 100%;
+    height: 100%;
 }
+
 html.nist-footer-bottom body {
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
 }
+
 html.nist-footer-bottom #main {
-  flex: 1 0 auto;
+    flex: 1 0 auto;
 }
+
 html.nist-footer-bottom .nist-footer {
-  flex-shrink: 0;
+    flex-shrink: 0;
+}
+
+.travis {
+    display: inline-block;
+    color: black;
+    text-align: center;
+    padding: 14px;
+    text-decoration: none;
+    font-size: 17px;
+    border-radius: 5px;
 }

--- a/docs_jekyll_uswds/_sass/uswds/uswds.scss
+++ b/docs_jekyll_uswds/_sass/uswds/uswds.scss
@@ -5,14 +5,12 @@
 @import 'lib/bourbon';
 @import 'lib/neat';
 @import 'lib/normalize';
-
 // Core -------------- //
 @import 'core/variables';
 @import 'core/fonts';
 @import 'core/grid';
 @import 'core/utilities';
 @import 'core/base';
-
 // Elements -------------- //
 // Styles basic HTML elements
 @import 'elements/buttons';
@@ -23,7 +21,6 @@
 @import 'elements/list';
 @import 'elements/table';
 @import 'elements/typography';
-
 // Components -------------- //
 @import 'components/accordions';
 @import 'components/alerts';
@@ -40,3 +37,6 @@
 @import 'components/section';
 @import 'components/sidenav';
 @import 'components/skipnav';
+//Bootstrap ----------------//
+$font-size-base: 17px;
+@import 'bootstrap';

--- a/docs_jekyll_uswds/schemas/_oscal-catalog/oscal-catalog.html
+++ b/docs_jekyll_uswds/schemas/_oscal-catalog/oscal-catalog.html
@@ -1,14 +1,9 @@
----
-title: oscal-catalog schema documentation 
-description: oscal-catalog schema documentation 
-permalink: /docs/schemaref/oscal-catalog/
-layout: post
-schema: oscal-catalog
-position: 0
----
-<h2 xmlns="http://www.w3.org/1999/xhtml" class="title">OSCAL Control Catalog Format: Schema Reference</h2><p xmlns="http://www.w3.org/1999/xhtml">The short name (file identifier) for this schema shall be <i>oscal-catalog</i>. It is used internally when an
-         identifier is called for, and may appear in file names of schema artifacts.</p><p xmlns="http://www.w3.org/1999/xhtml">The XML namespace for elements conformant to this schema:
-            <code>http://csrc.nist.gov/ns/oscal/1.0</code></p><div xmlns="http://www.w3.org/1999/xhtml" class="remarks">
+--- title: oscal-catalog schema documentation description: oscal-catalog schema documentation permalink: /docs/schemaref/oscal-catalog/ layout: post schema: oscal-catalog position: 0 ---
+<h2 xmlns="http://www.w3.org/1999/xhtml" class="title">OSCAL Control Catalog Format: Schema Reference</h2>
+<p xmlns="http://www.w3.org/1999/xhtml">The short name (file identifier) for this schema shall be <i>oscal-catalog</i>. It is used internally when an identifier is called for, and may appear in file names of schema artifacts.</p>
+<p xmlns="http://www.w3.org/1999/xhtml">The XML namespace for elements conformant to this schema:
+    <code>http://csrc.nist.gov/ns/oscal/1.0</code></p>
+<div xmlns="http://www.w3.org/1999/xhtml" class="remarks">
     <p class="p">The OSCAL Control Catalog format can be used to describe a collection of security controls and related sub-controls, along with a variety of control metadata. The root of the Control Catalog format is <a href="#catalog" class="name">catalog</a>.</p>
     <p class="p">An XML Schema is provided for the OSCAL Catalog XML model.</p>
-  </div>
+</div>

--- a/docs_jekyll_uswds/schemas/_oscal-catalog/oscal-catalog_address.html
+++ b/docs_jekyll_uswds/schemas/_oscal-catalog/oscal-catalog_address.html
@@ -1,16 +1,72 @@
 ---
-title: oscal-catalog address documentation 
+title: oscal-catalog address documentation
 tagname: address
-description: address element/object description | oscal-catalog schema 
+description: address element/object description | oscal-catalog schema
 permalink: /docs/schemas/_oscal-catalog/oscal-catalog_address/
 layout: post
 schema: oscal-catalog
 ---
-<div xmlns="http://www.w3.org/1999/xhtml" class="definition define-assembly" id="address"><h4 id="oscal-catalog_address"><b class="formal-name">Address</b>: <code class="name">address</code> assembly</h4><p class="description">A postal address</p><div class="model"><p>The <code class="name">address</code> assembly has the following contents  (in order):</p><ul>
-      <li class="assemblies"><a class="name" href="#addr-line"><code class="name">addr-line</code></a> fields (<i>zero or more</i>)</li>
-      <li>A <a class="name" href="#city"><code class="name">city</code></a> field  (<i>zero or one</i>)</li>
-      <li>A <a class="name" href="#state"><code class="name">state</code></a> field  (<i>zero or one</i>)</li>
-      <li>A <a class="name" href="#postal-code"><code class="name">postal-code</code></a> field  (<i>zero or one</i>)</li>
-      <li>A <a class="name" href="#country"><code class="name">country</code></a> field  (<i>zero or one</i>)</li>
-      
-    </ul></div><table class="usa-table-borderless"><caption>Properties</caption><thead><tr><th scope="col">Name</th><th scope="col">Metaschema type</th><th scope="col">Cardinality</th><th scope="col">Description / Remarks</th></tr></thead><tbody><tr><th scope="row"><span class="usa-label"><a class="name" href="#addr-line"><code class="name">addr-line</code></a></span></th><td>field</td><td> (<i>zero or one</i>)</td><td></td></tr><tr><th scope="row"><span class="usa-label"><a class="name" href="#city"><code class="name">city</code></a></span></th><td>field</td><td> (<i>zero or one</i>)</td><td></td></tr><tr><th scope="row"><span class="usa-label"><a class="name" href="#state"><code class="name">state</code></a></span></th><td>field</td><td> (<i>zero or one</i>)</td><td></td></tr><tr><th scope="row"><span class="usa-label"><a class="name" href="#postal-code"><code class="name">postal-code</code></a></span></th><td>field</td><td> (<i>zero or one</i>)</td><td></td></tr><tr><th scope="row"><span class="usa-label"><a class="name" href="#country"><code class="name">country</code></a></span></th><td>field</td><td> (<i>zero or one</i>)</td><td></td></tr></tbody></table></div>
+<div xmlns="http://www.w3.org/1999/xhtml" class="definition define-assembly container-fluid" id="address">
+    <div class="panel panel-success">
+      <div class="panel-heading"><b class="formal-name">Address</b>: <code class="name">address</code> assembly</div>
+      <div class="panel-body">
+        <p class="description">A postal address</p>
+        <div class="model">
+            <p>The <code class="name">address</code> assembly has the following contents (in order):</p>
+            <ul class="list-group">
+                <li class="assemblies" class="list-group-item">A <a class="name" href="#addr-line"><code class="name">addr-line</code></a> fields (<i>zero
+              or more</i>)</li>
+                <li class="list-group-item">A <a class="name" href="#city"><code class="name">city</code></a> field (<i>zero or one</i>)</li>
+                <li class="list-group-item">A <a class="name" href="#state"><code class="name">state</code></a> field (<i>zero or one</i>)</li>
+                <li class="list-group-item">A <a class="name" href="#postal-code"><code class="name">postal-code</code></a> field (<i>zero or one</i>)</li>
+                <li class="list-group-item">A <a class="name" href="#country"><code class="name">country</code></a> field (<i>zero or one</i>)</li>
+
+            </ul>
+        </div>
+        <!-- Table -->
+        <table class="table table-striped table-bordered">
+            <h4>Properties</h4>
+            <thead>
+                <tr class="info">
+                    <th scope="col">Name</th>
+                    <th scope="col">Metaschema type</th>
+                    <th scope="col">Cardinality</th>
+                    <th scope="col">Description / Remarks</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th scope="row"><span><a class="name" href="#addr-line"><code class="name">addr-line</code></a></span></th>
+                    <td>field</td>
+                    <td> (<i>zero or one</i>)</td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <th scope="row"><span><a class="name" href="#city"><code class="name">city</code></a></span></th>
+                    <td>field</td>
+                    <td> (<i>zero or one</i>)</td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <th scope="row"><span><a class="name" href="#state"><code class="name">state</code></a></span></th>
+                    <td>field</td>
+                    <td> (<i>zero or one</i>)</td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <th scope="row"><span><a class="name" href="#postal-code"><code class="name">postal-code</code></a></span></th>
+                    <td>field</td>
+                    <td> (<i>zero or one</i>)</td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <th scope="row"><span><a class="name" href="#country"><code class="name">country</code></a></span></th>
+                    <td>field</td>
+                    <td> (<i>zero or one</i>)</td>
+                    <td></td>
+                </tr>
+            </tbody>
+        </table>
+      </div>
+    </div>
+</div>


### PR DESCRIPTION
# Committer Notes

This commit pulls in Wendell's changes to the auto-HTML generation from schema.  I applied new formatting to include Bootstrap styling to pretty up the HTML and better visually organize the content.  The Address html has the new formatting example.  Wendell should be able to use that code to update the transform for all of the sections.

### All Submissions:

* [x ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]

### Changes to Core Features:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x] Have you written new tests for your core changes, as applicable?
* [ x] Have you included examples of how to use your new feature(s)?
